### PR TITLE
fix: Correct ambiguous relationship in pipeline query

### DIFF
--- a/src/components/HiringPipeline.tsx
+++ b/src/components/HiringPipeline.tsx
@@ -127,7 +127,7 @@ const HiringPipeline: React.FC<HiringPipelineProps> = ({ onSendMessage, onViewDe
                             profile_pic_url
                         )
                     ),
-                    job_role:job_roles!inner (
+                    job_role:job_roles!fk_assignments_job_role_id!inner (
                         id,
                         title
                     )


### PR DESCRIPTION
This commit resolves an error in the hiring pipeline where the query to fetch candidates was failing due to an ambiguous relationship between the `assignments` and `job_roles` tables.

The fix explicitly specifies the foreign key to use in the Supabase query, resolving the ambiguity and allowing the pipeline to load correctly.