### PR TITLE
fix: Correct developer selection in pipeline query

### DIFF
--- a/src/components/HiringPipeline.tsx
+++ b/src/components/HiringPipeline.tsx
@@ -118,7 +118,6 @@ const HiringPipeline: React.FC<HiringPipelineProps> = ({ onSendMessage, onViewDe
                     notes,
                     assigned_at,
                     developer:developers!inner (
-                        id,
                         user_id,
                         user:users!inner (
                             id,


### PR DESCRIPTION
This commit resolves an error in the hiring pipeline where the query to fetch candidates was failing because the `developers` table does not have an `id` column.

The fix removes the `id` column from the `developer` selection in the Supabase query, resolving the error and allowing the pipeline to load correctly.