### PR TITLE
fix: Use correct developer user_id for sending tests

### DIFF
--- a/src/components/HiringPipeline.tsx
+++ b/src/components/HiringPipeline.tsx
@@ -349,7 +349,7 @@ const HiringPipeline: React.FC<HiringPipelineProps> = ({ onSendMessage, onViewDe
                                                 onClick={() => onSendMessage(c.developer.user_id, c.developer.user.name || '', c.job_role.id, c.job_role.title)}
                                                 className="p-2 hover:bg-gray-100 rounded-full text-gray-600" title="Message Candidate"><MessageSquare size={18} />
                                             </button>
-                                            <button onClick={() => handleOpenSendTestModal(c.developer.id, c.job_role.id)} className="p-2 hover:bg-gray-100 rounded-full text-gray-600" title="Send Test">
+                                            <button onClick={() => handleOpenSendTestModal(c.developer.user_id, c.job_role.id)} className="p-2 hover:bg-gray-100 rounded-full text-gray-600" title="Send Test">
                                                 <Code size={18} />
                                             </button>
                                             {c.test_assignment && (


### PR DESCRIPTION
This commit fixes an issue where the 'Send Test' button was not working correctly. The `handleOpenSendTestModal` function was being called with `c.developer.id`, but it should be `c.developer.user_id`.

This change ensures that the correct developer ID is used, allowing the 'Send Test' button to function correctly.