### PR TITLE
feat: Add link to test management page from admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -502,6 +502,14 @@ export const AdminDashboard = () => {
             <span className="font-semibold text-gray-900">View Hires</span>
             <span className="text-sm text-gray-600 mt-1">Track successful placements</span>
           </button>
+          <button
+            onClick={() => navigate('/admin/tests')}
+            className="flex flex-col items-center justify-center p-6 bg-gray-50 rounded-xl border border-gray-100 hover:bg-gray-100 transition-colors"
+          >
+            <Code className="w-8 h-8 text-gray-600 mb-3" />
+            <span className="font-semibold text-gray-900">Manage Tests</span>
+            <span className="text-sm text-gray-600 mt-1">Create and edit coding tests</span>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
This commit adds a 'Manage Coding Tests' card to the admin dashboard, providing a clear and easy way for admins to access the test management page.

This improves the user experience for admins who need to create, edit, or delete coding tests.