### PR TITLE
fix: Create notifications for test assignments

### DIFF
--- a/supabase/functions/notify-user/index.ts
+++ b/supabase/functions/notify-user/index.ts
@@ -9,16 +9,43 @@ serve(async (req) => {
   try {
     const { type, record } = await req.json()
 
+    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2')
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: req.headers.get('Authorization')! } } }
+    )
+
     let message = ''
+    let userId = ''
 
     if (type === 'INSERT' && record.table === 'test_assignments') {
       // Notify developer
       message = `You have been assigned a new coding test.`
-      console.log(`Notifying developer ${record.developer_id}: ${message}`)
+      userId = record.developer_id
     } else if (type === 'UPDATE' && record.table === 'test_assignments' && record.status === 'Completed') {
       // Notify recruiter
+      const { data: assignment, error } = await supabase
+        .from('assignments')
+        .select('recruiter_id')
+        .eq('test_assignment_id', record.id)
+        .single()
+
+      if (error) {
+        throw error
+      }
+
       message = `A developer has completed a coding test.`
-      console.log(`Notifying recruiter for assignment ${record.id}: ${message}`)
+      userId = assignment.recruiter_id
+    }
+
+    if (message && userId) {
+      await supabase.from('notifications').insert({
+        user_id: userId,
+        message,
+        type: 'test_assignment',
+        entity_id: record.id,
+      })
     }
 
     return new Response(JSON.stringify({ message: 'Notification processed' }), {


### PR DESCRIPTION
This commit fixes an issue where developers were not being notified when they were assigned a coding test. The `notify-user` edge function was only logging to the console, not creating a notification in the database.

This change updates the `notify-user` function to insert a new row into the `notifications` table, ensuring that developers are properly notified when they are assigned a test.