### PR TITLE
feat: Add developer tests page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { AuthCallback } from './pages/AuthCallback';
 import { ApplyForJob } from './pages/ApplyForJob';
 import TestPage from './pages/TestPage';
 import AdminTests from './pages/AdminTests';
+import DeveloperTests from './pages/DeveloperTests';
 
 // !! NEW IMPORT !!
 import EndorsementPage from './pages/EndorsementPage'; // Assuming default export for EndorsementPage
@@ -46,6 +47,7 @@ function App() {
           <Route path="/admin/tests" element={<AdminTests />} />
           <Route path="/recruiter" element={<RecruiterDashboard />} />
           <Route path="/developer" element={<DeveloperDashboard />} />
+          <Route path="/developer/tests" element={<DeveloperTests />} />
 
           {/* Navigation Redirects (if any) */}
           <Route path="/dashboard/jobs" element={<Navigate to="/developer?tab=jobs" />} />

--- a/src/pages/DeveloperDashboard.tsx
+++ b/src/pages/DeveloperDashboard.tsx
@@ -72,7 +72,7 @@ interface DashboardLocationState {
 }
 
 const initialStateForGitHubData = { user: null, repos: [], languages: {}, totalStars: 0, contributions: [] };
-const validTabs = ['overview', 'profile', 'portfolio', 'github-activity', 'messages', 'jobs', 'endorsements'];
+const validTabs = ['overview', 'profile', 'portfolio', 'github-activity', 'messages', 'jobs', 'endorsements', 'tests'];
 
 export const DeveloperDashboard: React.FC = () => {
   const {
@@ -489,6 +489,7 @@ export const DeveloperDashboard: React.FC = () => {
         </div>
       )}
       {activeTab === 'jobs' && <JobsTab />}
+      {activeTab === 'tests' && <DeveloperTests />}
       {activeTab === 'endorsements' && (
         <section className="endorsements-tab-content">
             <EndorsementDisplay

--- a/src/pages/DeveloperTests.tsx
+++ b/src/pages/DeveloperTests.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { supabase } from '../lib/supabase';
+import { TestAssignment } from '../types';
+import { Link } from 'react-router-dom';
+import { Code, Clock, CheckCircle } from 'lucide-react';
+
+const DeveloperTests: React.FC = () => {
+    const { userProfile } = useAuth();
+    const [assignments, setAssignments] = useState<TestAssignment[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (userProfile) {
+            fetchAssignments();
+        }
+    }, [userProfile]);
+
+    const fetchAssignments = async () => {
+        if (!userProfile) return;
+        setLoading(true);
+        const { data, error } = await supabase
+            .from('test_assignments')
+            .select('*, coding_tests(*)')
+            .eq('developer_id', userProfile.id);
+
+        if (error) {
+            console.error('Error fetching assignments:', error);
+        } else {
+            setAssignments(data as TestAssignment[]);
+        }
+        setLoading(false);
+    };
+
+    return (
+        <div className="p-4">
+            <h1 className="text-2xl font-bold mb-4">My Coding Tests</h1>
+            {loading ? (
+                <p>Loading...</p>
+            ) : assignments.length === 0 ? (
+                <p>You have not been assigned any tests yet.</p>
+            ) : (
+                <div className="space-y-4">
+                    {assignments.map(assignment => (
+                        <div key={assignment.id} className="p-4 border rounded-md flex justify-between items-center">
+                            <div>
+                                <h2 className="text-xl font-semibold">{assignment.coding_tests.title}</h2>
+                                <p className="text-gray-600">{assignment.coding_tests.description}</p>
+                                <div className="flex items-center text-sm text-gray-500 mt-2">
+                                    {assignment.status === 'Completed' ? (
+                                        <CheckCircle className="w-4 h-4 mr-2 text-green-500" />
+                                    ) : (
+                                        <Clock className="w-4 h-4 mr-2 text-yellow-500" />
+                                    )}
+                                    <span>{assignment.status}</span>
+                                </div>
+                            </div>
+                            <div>
+                                {assignment.status === 'Pending' && (
+                                    <Link to={`/test/${assignment.id}`} className="px-4 py-2 bg-blue-600 text-white rounded-md flex items-center">
+                                        <Code size={16} className="mr-2" /> Start Test
+                                    </Link>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default DeveloperTests;


### PR DESCRIPTION
This commit adds a new page where developers can view their assigned coding tests. This provides a more reliable way for developers to access their tests than the notification system.

This change includes:
- A new 'My Tests' tab on the developer dashboard
- A new page at `/developer/tests` that displays a list of assigned tests
- A new route in `App.tsx` for the developer tests page