### PR TITLE
fix: Correctly import DeveloperTests component

### DIFF
--- a/src/pages/DeveloperDashboard.tsx
+++ b/src/pages/DeveloperDashboard.tsx
@@ -25,8 +25,9 @@ import { useGitHub } from '../hooks/useGitHub';
 import { useFreshGitHubDataOnce } from '../hooks/useFreshGitHubDataOnce';
 import {
   User, Briefcase, MessageSquare, Search, Github, Star, TrendingUp, Calendar,
-  DollarSign, MapPin, Clock, Send, ExternalLink, Building, Eye, SearchCheck, Loader, AlertCircle,
+  DollarSign, MapPin, Clock, Send, ExternalLink, Building, Eye, SearchCheck, Loader, AlertCircle, Code,
 } from 'lucide-react';
+import DeveloperTests from './DeveloperTests';
 import {
   Developer,
   JobRole,


### PR DESCRIPTION
This commit fixes an issue where the developer dashboard would crash when navigating to the 'My Tests' tab. The `DeveloperTests` component was not being imported correctly.

This change corrects the import, ensuring that the 'My Tests' tab displays correctly.