### PR TITLE
fix: Prevent crash on test page with no questions

### DIFF
--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -121,6 +121,10 @@ const TestPage: React.FC = () => {
         return <div>Test not found.</div>;
     }
 
+    if (questions.length === 0) {
+        return <div>This test has no questions.</div>;
+    }
+
     const currentQuestion = questions[currentQuestionIndex];
 
     return (


### PR DESCRIPTION
This commit fixes an issue where the test page would crash if a test had no questions. It adds a check to ensure that the `questions` array is not empty before trying to render the current question.

This improves the robustness of the test page and prevents a poor user experience.