### PR TITLE
fix: Correct import path for cors.ts

### DIFF
--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { corsHeaders } from '../_shared/cors.ts'
+import { corsHeaders } from './_shared/cors.ts'
 
 const JUDGE0_API_URL = 'https://judge0-ce.p.rapidapi.com';
 


### PR DESCRIPTION
This commit fixes an issue where the `grade-submission` edge function was failing to deploy due to an incorrect import path for the `cors.ts` file.

This change updates the import path to correctly point to the `_shared/cors.ts` file, allowing the edge function to be deployed successfully.