### PR TITLE
fix: Add title field to coding questions

### DIFF
--- a/src/pages/AdminTests.tsx
+++ b/src/pages/AdminTests.tsx
@@ -117,7 +117,7 @@ const AdminTests: React.FC = () => {
                         <div className="mt-4">
                             <h3 className="font-bold">Questions</h3>
                             <button onClick={() => fetchQuestions(test.id)} className="text-sm text-blue-600">Load Questions</button>
-                            <button onClick={() => setEditingQuestion({ test_id: test.id, language: 'python' })} className="ml-4 px-2 py-1 bg-gray-200 rounded-md text-sm">Add Question</button>
+                            <button onClick={() => setEditingQuestion({ test_id: test.id, title: '', language: 'python' })} className="ml-4 px-2 py-1 bg-gray-200 rounded-md text-sm">Add Question</button>
                             {questions[test.id] && (
                                 <div className="space-y-2 mt-2">
                                     {questions[test.id].map(q => (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -291,6 +291,7 @@ export interface CodingTest {
 export interface CodingQuestion {
     id: string;
     test_id: string;
+    title: string;
     question_text: string;
     language: string;
     starter_code?: string;


### PR DESCRIPTION
This commit fixes an issue where questions could not be saved due to a missing `title` field. The `title` field was added to the database schema, but the frontend was not sending it to the API.

This change adds the `title` field to the `CodingQuestion` type and the `editingQuestion` state, ensuring that the `title` is sent to the API when a question is saved.