### PR TITLE
fix: Pass language to grade-submission edge function

### DIFF
--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -83,7 +83,7 @@ const TestPage: React.FC = () => {
         const { data, error } = await supabase.functions.invoke('grade-submission', {
             body: {
                 code,
-                language_id: getLanguageId(question.language),
+                language: question.language,
                 stdin: question.test_cases?.[0]?.stdin || '',
             },
         });
@@ -103,7 +103,7 @@ const TestPage: React.FC = () => {
         const { data, error } = await supabase.functions.invoke<{ status: { id: number }, stdout: string, stderr: string }>('grade-submission', {
             body: {
                 code,
-                language_id: getLanguageId(question.language),
+                language: question.language,
                 stdin: question.test_cases?.[0]?.stdin || '',
                 expected_output: question.expected_output,
             },


### PR DESCRIPTION
This commit fixes an issue where the `grade-submission` edge function was not receiving the correct language from the `TestPage` component. The `TestPage` component was passing the `language_id` directly, which was causing the switch statement in the `grade-submission` edge function to not work correctly.

This change updates the `TestPage` component to pass the `language` to the `grade-submission` edge function, allowing the edge function to correctly determine the `language_id`.