### PR TITLE
fix: Correctly pass language_id to grade-submission

### DIFF
--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -76,6 +76,27 @@ const TestPage: React.FC = () => {
         }
     }
 
+    const getLanguageId = (language: string) => {
+        switch (language) {
+            case 'python':
+                return 71;
+            case 'javascript':
+                return 63;
+            case 'java':
+                return 62;
+            case 'c++':
+                return 54;
+            case 'react':
+                return 63; // Use JavaScript for React
+            case 'angular':
+                return 63; // Use JavaScript for Angular
+            case 'vue':
+                return 63; // Use JavaScript for Vue
+            default:
+                return 71; // Default to Python
+        }
+    }
+
     const handleRunCode = async () => {
         setOutput('');
         setIsSubmitting(true);
@@ -83,7 +104,7 @@ const TestPage: React.FC = () => {
         const { data, error } = await supabase.functions.invoke('grade-submission', {
             body: {
                 code,
-                language: question.language,
+                language_id: getLanguageId(question.language),
                 stdin: question.test_cases?.[0]?.stdin || '',
             },
         });
@@ -103,7 +124,7 @@ const TestPage: React.FC = () => {
         const { data, error } = await supabase.functions.invoke<{ status: { id: number }, stdout: string, stderr: string }>('grade-submission', {
             body: {
                 code,
-                language: question.language,
+                language_id: getLanguageId(question.language),
                 stdin: question.test_cases?.[0]?.stdin || '',
                 expected_output: question.expected_output,
             },

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -13,34 +13,7 @@ serve(async (req) => {
   }
 
   try {
-    const { code, language, stdin, expected_output } = await req.json()
-
-    let language_id;
-    switch (language) {
-        case 'python':
-            language_id = 71;
-            break;
-        case 'javascript':
-            language_id = 63;
-            break;
-        case 'java':
-            language_id = 62;
-            break;
-        case 'c++':
-            language_id = 54;
-            break;
-        case 'react':
-            language_id = 63; // Use JavaScript for React
-            break;
-        case 'angular':
-            language_id = 63; // Use JavaScript for Angular
-            break;
-        case 'vue':
-            language_id = 63; // Use JavaScript for Vue
-            break;
-        default:
-            language_id = 71; // Default to Python
-    }
+    const { code, language_id, stdin, expected_output } = await req.json()
 
     const response = await fetch(`${JUDGE0_API_URL}/submissions`, {
       method: 'POST',


### PR DESCRIPTION
This commit fixes an issue where the `grade-submission` edge function was not receiving the correct `language_id` from the `TestPage` component. The `TestPage` component was passing the `language` instead of the `language_id`.

This change updates the `TestPage` component to pass the `language_id` to the `grade-submission` edge function, and updates the `grade-submission` edge function to use the `language_id`.