### PR TITLE
feat: Add Sandpack admin workflow for multi-framework tests

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -114,6 +114,20 @@ const SandpackTest: React.FC<SandpackTestProps> = ({
 }) => {
   const { setup, mainFile, testFile } = getFrameworkConfig(framework);
 
+  // Explicitly create a package.json file for the sandbox
+  const packageJson = JSON.stringify({
+    name: `gittalent-${framework}-challenge`,
+    version: '1.0.0',
+    main: mainFile,
+    dependencies: setup.dependencies,
+    scripts: {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    }
+  });
+
   const files: SandpackFiles = {
     [mainFile]: {
       code: starterCode,
@@ -123,12 +137,18 @@ const SandpackTest: React.FC<SandpackTestProps> = ({
       code: testCode,
       hidden: true,
     },
+    // Add the package.json to the files object
+    '/package.json': {
+      code: packageJson,
+      hidden: true,
+    }
   };
 
   return (
     <SandpackProvider
       template={framework}
-      customSetup={setup}
+      // customSetup is no longer needed as we provide an explicit package.json
+      // customSetup={setup}
       files={files}
       options={{
         showTabs: true,


### PR DESCRIPTION
This commit enhances the coding test feature to support multi-framework challenges using Sandpack, fully integrated with the admin dashboard.

Key changes:
- The `coding_questions` table is updated to support storing framework-based test code.
- The `AdminTests.tsx` page is modified to allow admins to create both Judge0-style and Sandpack-style questions. The UI conditionally changes based on the selected language (React, Vue, Angular).
- A new, refactored `SandpackTest.tsx` component is introduced that can dynamically load and run challenges for multiple frameworks. It now explicitly generates a `package.json` for the sandbox to ensure robust environment setup.
- Example code for React, Vue, and Angular counter challenges is provided for initial test creation.

This also fixes a bug where the Sandpack environment for React was not being initialized correctly, causing a `SyntaxError: Cannot use import statement outside a module`.