### PR TITLE
fix: Add defensive lowercase to Sandpack template prop

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -146,7 +146,7 @@ const SandpackTest: React.FC<SandpackTestProps> = ({
 
   return (
     <SandpackProvider
-      template={framework}
+      template={framework.toLowerCase() as SupportedFramework}
       // customSetup is no longer needed as we provide an explicit package.json
       // customSetup={setup}
       files={files}


### PR DESCRIPTION
This commit applies a defensive fix to the `SandpackTest.tsx` component to prevent issues with template resolution.

The `framework` prop is now forced to lowercase before being passed to the `template` prop of the `SandpackProvider`. This ensures that minor case differences in the data (e.g., "React" vs. "react") do not cause Sandpack to fall back to the default Node.js environment, which was causing a "Cannot use import statement outside a module" error.

This change makes the component more robust and should resolve the persistent runtime error.