### PR TITLE
diag: Add logging to debug Sandpack crash

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -86,6 +86,7 @@ const SupabaseTestReporter: React.FC<{
   const { sandpack } = useSandpack();
 
   useEffect(() => {
+    console.log('[SupabaseTestReporter] sandpack object:', sandpack);
     // This effect should only run once to set up the listener
     const stopListening = sandpack.listen(async (message) => {
       if (message.type === 'test:end') {


### PR DESCRIPTION
This commit adds diagnostic logging to `SandpackTest.tsx` to investigate a runtime crash (`TypeError: s.listen is not a function`).

A `console.log` has been added to the `SupabaseTestReporter` component to inspect the `sandpack` object provided by the `useSandpack` hook at the moment the `.listen()` method is called. This will help determine if the object is null or not what is expected at that point in the component lifecycle.