### PR TITLE
fix: Use onComplete prop to get Sandpack test results

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -103,21 +103,12 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
   const [testResults, setTestResults] = useState<SandpackTestsProps | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
-    // A robust guard clause to ensure the client and listen method are available
-    if (!sandpack || typeof sandpack.listen !== 'function') {
-      return;
-    }
-    const stopListening = sandpack.listen((message) => {
-      if (message.type === 'test:end') {
-        setTestResults(message.payload);
-      }
-    });
-    return () => stopListening();
-  }, [sandpack]);
-
   const runTests = () => {
     sandpack.runTests();
+  };
+
+  const handleTestComplete = (payload: SandpackTestsProps) => {
+    setTestResults(payload);
   };
 
   const submitSolution = async () => {
@@ -161,6 +152,7 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
         <SandpackTests
           style={{ height: '60vh' }}
           headerChildren={<CustomTestHeader onRunTests={runTests} />}
+          onComplete={handleTestComplete}
         />
       </SandpackLayout>
       <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'flex-end' }}>


### PR DESCRIPTION
This commit provides the definitive fix for the Sandpack integration by refactoring the component to use the correct API for retrieving test results.

The root cause of the silent test runner failure was an incorrect implementation that used a manual `sandpack.listen` event listener. The correct approach, implemented here, is to use the `onComplete` callback prop on the `<SandpackTests />` component.

Changes:
- The `useEffect` hook that contained the manual listener has been removed.
- A new handler function, `handleTestComplete`, is created to receive the test results payload.
- This handler is passed to the `<SandpackTests onComplete={...} />` prop.

This aligns the component with the intended architecture of the Sandpack library, resolves the communication failure, and allows the 'Submit' button to be enabled correctly when tests pass.