### PR TITLE
diag: Log the onComplete payload from Sandpack

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -108,6 +108,7 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
   };
 
   const handleTestComplete = (payload: SandpackTestsProps) => {
+    console.log('[Sandpack] onComplete payload:', payload);
     setTestResults(payload);
   };
 


### PR DESCRIPTION
This commit adds diagnostic logging to investigate a `TypeError: Cannot read properties of undefined (reading 'every')`.

A `console.log` has been added to the `handleTestComplete` function in `SandpackTest.tsx` to log the raw payload received from the `onComplete` prop of the `<SandpackTests>` component. This will allow us to inspect the true structure of the test results object and fix the logic that parses it.