### PR TITLE
diag: Use JSON.stringify to inspect Sandpack payload

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -108,7 +108,7 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
   };
 
   const handleTestComplete = (payload: SandpackTestsProps) => {
-    console.log('[Sandpack] onComplete payload:', payload);
+    console.log('[Sandpack] onComplete payload:', JSON.stringify(payload, null, 2));
     setTestResults(payload);
   };
 


### PR DESCRIPTION
This commit adds more detailed diagnostic logging to `SandpackTest.tsx`.

The `console.log` in the `handleTestComplete` function is updated to use `JSON.stringify(payload, null, 2)`. This will pretty-print the entire structure of the payload received from the `onComplete` event, allowing for a definitive analysis of its shape. This is to debug a `TypeError` which suggests the payload's structure is not what is expected.