### PR TITLE
fix: Remove redundant logic in submit handler

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -112,11 +112,8 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
   };
 
   const submitSolution = async () => {
-    if (!testResults) {
-      alert('Please run the tests before submitting.');
-      return;
-    }
-    const allTestsPassed = testResults.tests.every((t) => t.status === 'pass');
+    // The button's disabled state already prevents this from being called
+    // unless allTestsPassed is true. No need to re-check here.
     if (!allTestsPassed) {
       alert('Please ensure all tests are passing before you submit.');
       return;


### PR DESCRIPTION
This commit fixes the final bug that was causing a `TypeError` when clicking the "Submit Solution" button.

The root cause was a piece of old, incorrect logic inside the `submitSolution` function that was attempting to re-parse the test results object. The button was being enabled by the new, correct logic, but the click handler was crashing because of the old, incorrect logic.

This commit removes the redundant and incorrect check from the `submitSolution` handler. The function now relies on the `allTestsPassed` state that is used to enable the button, ensuring consistency and preventing the crash.

This should be the definitive fix for all reported issues.