### PR TITLE
fix: Align Sandpack submission payload with DB schema

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -142,6 +142,8 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
         results: testResults,
         passed_test_cases: passed_test_cases,
         total_test_cases: total_test_cases,
+        stdout: JSON.stringify(testResults, null, 2), // Add for schema compatibility
+        stderr: '', // Add for schema compatibility
       });
       if (error) throw error;
       console.log('Solution submitted successfully!');


### PR DESCRIPTION
This commit fixes a 400 Bad Request error that occurred when submitting a Sandpack test result.

The root cause was a mismatch between the data payload being sent by the client and the schema of the `test_results` table in the database. The client was not including the `stdout` and `stderr` fields, which are present in the Judge0 workflow and likely have a `NOT NULL` constraint.

This commit updates the `insert` call in the `submitSolution` function to include the `stdout` and `stderr` fields, ensuring the payload conforms to the expected database schema. The full Sandpack results object is stringified and placed in `stdout` for logging and debugging purposes.