### PR TITLE
fix: Match test_results schema and remove non-existent column

### DIFF
--- a/src/components/Tests/SandpackTest.tsx
+++ b/src/components/Tests/SandpackTest.tsx
@@ -139,11 +139,10 @@ const SandpackLayoutManager: React.FC<Omit<SandpackTestProps, 'framework'>> = ({
         assignment_id: assignmentId,
         question_id: questionId,
         score: 1, // This is based on allTestsPassed, so it's already correct
-        results: testResults,
         passed_test_cases: passed_test_cases,
         total_test_cases: total_test_cases,
-        stdout: JSON.stringify(testResults, null, 2), // Add for schema compatibility
-        stderr: '', // Add for schema compatibility
+        stdout: JSON.stringify(testResults, null, 2), // For logging/debugging
+        stderr: '', // For schema compatibility
       });
       if (error) throw error;
       console.log('Solution submitted successfully!');


### PR DESCRIPTION
This commit provides the definitive fix for the 400 Bad Request error.

The root cause, identified by inspecting the table schema, was that the client was attempting to insert data into a `results` column that does not exist on the `test_results` table.

This commit removes the `results` field from the `insert` payload in the `submitSolution` function. The detailed test results are already being correctly stringified and saved in the `stdout` column for logging and review purposes.

This change aligns the submission payload with the exact database schema and should resolve the final outstanding issue.