### PR TITLE
fix: Prevent crash when marking candidate as hired

### DIFF
--- a/src/components/Hires/MarkAsHiredModal.tsx
+++ b/src/components/Hires/MarkAsHiredModal.tsx
@@ -189,9 +189,9 @@ export const MarkAsHiredModal: React.FC<MarkAsHiredModalProps> = ({
           <div className="bg-gray-50 rounded-xl p-4 mb-6 border border-gray-200">
             <h3 className="font-bold text-gray-900 mb-2">Assignment Details</h3>
             <div className="text-sm text-gray-600 space-y-1">
-              <div><strong>Developer:</strong> {assignment.developer.user.name}</div>
+              <div><strong>Developer:</strong> {assignment.developer.user?.name}</div>
               <div><strong>Job:</strong> {assignment.job_role.title}</div>
-              <div><strong>Company:</strong> {assignment.recruiter.user.company_name}</div>
+              <div><strong>Company:</strong> {assignment.job_role.recruiter?.company_name}</div>
             </div>
           </div>
 

--- a/src/components/HiringPipeline.tsx
+++ b/src/components/HiringPipeline.tsx
@@ -128,7 +128,10 @@ const HiringPipeline: React.FC<HiringPipelineProps> = ({ onSendMessage, onViewDe
                     ),
                     job_role:job_roles!fk_assignments_job_role_id!inner (
                         id,
-                        title
+                        title,
+                        recruiter:recruiters!fk_job_roles_recruiter_user_id (
+                            company_name
+                        )
                     ),
                     test_assignment:test_assignments (
                         id,


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when a recruiter changed a candidate's status to "Hired" in the hiring pipeline.

The root cause was that the `MarkAsHiredModal` component was trying to access `assignment.recruiter.user.company_name`, but the `recruiter` object was not being fetched in the initial query from `HiringPipeline.tsx`.

This commit includes two fixes:
1.  The Supabase query in `HiringPipeline.tsx` is updated to correctly fetch the nested `company_name` via the job role.
2.  The JSX in `MarkAsHiredModal.tsx` is updated to access the company name via the correct data path (`assignment.job_role.recruiter.company_name`) and adds optional chaining for safety.