### PR TITLE
Fix: Resolve infinite loading state on recruiter signup

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -753,6 +753,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     email: string,
     password: string,
     userData: Partial<User>,
+    options?: { emailRedirectTo?: string }
   ): Promise<{ data?: any; error: any | null }> => {
     try {
       setAuthError(null);
@@ -760,7 +761,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { name: userData.name, role: userData.role } },
+        options: {
+          data: { name: userData.name, role: userData.role },
+          emailRedirectTo: options?.emailRedirectTo,
+        },
       });
       if (error) {
         setAuthError(error.message);
@@ -770,6 +774,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       if (data.user && userData.role === 'developer') {
         await createDeveloperProfile(data.user.id, {});
       }
+      setLoading(false); // Fix: Ensure loading is set to false on success
       return { data, error: null };
     } catch (error: any) {
       const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';


### PR DESCRIPTION
This commit fixes a bug where the UI would hang on the "Checking authentication..." message after a new recruiter signed up.

The issue was caused by the `loading` state in `AuthContext` not being reset to `false` after a successful `signUp` call.

The `signUp` function in `src/contexts/AuthContext.tsx` has been modified to ensure `setLoading(false)` is called on a successful response from Supabase, which resolves the infinite loading state. The function signature was also updated to correctly handle the `emailRedirectTo` option.