### PR TITLE
Fix: Scroll to top after recruiter signup

### DIFF
--- a/src/components/Auth/SignupForm.tsx
+++ b/src/components/Auth/SignupForm.tsx
@@ -91,6 +91,7 @@ export const SignupForm = () => {
       
       if (formData.role === 'recruiter') {
         setSuccess('Please check your email to confirm your account.');
+        window.scrollTo(0, 0);
       } else {
         setSuccess('Account created successfully! Redirecting to dashboard...');
       }


### PR DESCRIPTION
This commit fixes a user experience issue where the success message on the recruiter signup form was not immediately visible after submission because the page was scrolled down.

The `handleSubmit` function in `src/components/Auth/SignupForm.tsx` has been modified to call `window.scrollTo(0, 0)` after a successful signup, ensuring the success message is in view for the user.