### PR TITLE
Fix: Correctly format 'to' field in Resend API calls

### DIFF
--- a/supabase/functions/send-email-notifications/index.ts
+++ b/supabase/functions/send-email-notifications/index.ts
@@ -247,7 +247,7 @@ async function sendViaResend(to, subject, html, text) {
     },
     body: JSON.stringify({
       from: EMAIL_FROM,
-      to,
+      to: [to],
       subject,
       html,
       text

--- a/supabase/functions/send-endorsement-invite/index.ts
+++ b/supabase/functions/send-endorsement-invite/index.ts
@@ -59,7 +59,7 @@ async function sendViaResend(to, subject, html, text) {
     },
     body: JSON.stringify({
       from: EMAIL_FROM,
-      to,
+      to: [to],
       subject,
       html,
       text


### PR DESCRIPTION
The Resend API expects the 'to' field to be an array of strings. In the `send-email-notifications` and `send-endorsement-invite` edge functions, the 'to' field was being passed as a single string, which caused the API to return a 400 Bad Request error.

This commit fixes the issue by wrapping the 'to' email address in an array in the `sendViaResend` function in both `send-email-notifications/index.ts` and `send-endorsement-invite/index.ts`.